### PR TITLE
fix: resolve pnpm version conflict in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Removes explicit `version: 10` from `pnpm/action-setup@v4` in the deploy workflow
- `pnpm/action-setup@v4` errors when both `version` in workflow and `packageManager` in `package.json` are specified
- Now reads version from `packageManager` field in `package.json` (pnpm@10.11.0)

## Test plan
- [ ] Merge → verify GitHub Actions deploy workflow succeeds
- [ ] Verify site loads at https://rockroque.github.io/rockroque.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)